### PR TITLE
Remove extraneous change dirs

### DIFF
--- a/docs/kotlin/getting-started.md
+++ b/docs/kotlin/getting-started.md
@@ -92,7 +92,7 @@ are the input and output for the `Say` RPC method.
 We're going to generate our code using [`buf`][buf], a modern replacement for
 Google's protobuf compiler.
 
-First, scaffold a basic [`buf.yaml`][buf.yaml] by running `buf config init`. Then, edit `buf.yaml`
+First, scaffold a basic [`buf.yaml`][buf.yaml] by running `buf config init` at the root of your repository. Then, edit `buf.yaml`
 to use our `proto` directory:
 
 ```yaml title=buf.yaml

--- a/docs/kotlin/getting-started.md
+++ b/docs/kotlin/getting-started.md
@@ -92,10 +92,6 @@ are the input and output for the `Say` RPC method.
 We're going to generate our code using [`buf`][buf], a modern replacement for
 Google's protobuf compiler.
 
-```bash
-$ cd ..
-```
-
 First, scaffold a basic [`buf.yaml`][buf.yaml] by running `buf config init`. Then, edit `buf.yaml`
 to use our `proto` directory:
 

--- a/docs/node/getting-started.md
+++ b/docs/node/getting-started.md
@@ -73,7 +73,7 @@ but we also need a configuration file to get going. (If you'd prefer, you can
 skip this section and use `protoc` instead &mdash; `protoc-gen-connect-es`
 behaves like any other plugin.)
 
-First, scaffold a basic [`buf.yaml`][buf.yaml]:
+First, scaffold a basic [`buf.yaml`][buf.yaml] at the root of your repository:
 
 ```bash
 $ npx buf config init

--- a/docs/node/getting-started.md
+++ b/docs/node/getting-started.md
@@ -73,10 +73,6 @@ but we also need a configuration file to get going. (If you'd prefer, you can
 skip this section and use `protoc` instead &mdash; `protoc-gen-connect-es`
 behaves like any other plugin.)
 
-```bash
-$ cd ..
-```
-
 First, scaffold a basic [`buf.yaml`][buf.yaml]:
 
 ```bash

--- a/docs/swift/getting-started.md
+++ b/docs/swift/getting-started.md
@@ -76,10 +76,6 @@ We're going to generate our code using [Buf][buf], a modern replacement for
 Google's protobuf compiler. We installed Buf earlier, but we also need a few
 configuration files to get going.
 
-```bash
-$ cd ..
-```
-
 First, scaffold a basic [`buf.yaml`][buf.yaml] by running `buf config init`. Then, edit `buf.yaml`
 to use our `proto` directory:
 

--- a/docs/swift/getting-started.md
+++ b/docs/swift/getting-started.md
@@ -76,7 +76,7 @@ We're going to generate our code using [Buf][buf], a modern replacement for
 Google's protobuf compiler. We installed Buf earlier, but we also need a few
 configuration files to get going.
 
-First, scaffold a basic [`buf.yaml`][buf.yaml] by running `buf config init`. Then, edit `buf.yaml`
+First, scaffold a basic [`buf.yaml`][buf.yaml] by running `buf config init` at the root of your repository. Then, edit `buf.yaml`
 to use our `proto` directory:
 
 ```yaml title=buf.yaml


### PR DESCRIPTION
This change removes extraneous `cd ..` invocations in "getting started" guides.